### PR TITLE
Init freq channels

### DIFF
--- a/martini/datacube.py
+++ b/martini/datacube.py
@@ -73,18 +73,19 @@ class DataCube(object):
         self.velocity_centre = velocity_centre.to(
             U.m / U.s, equivalencies=U.doppler_radio(HIfreq)
         )
-        self.channel_width = (
-            velocity_centre.to(
-                channel_width.unit, equivalencies=U.doppler_radio(HIfreq)
-            )
-            + 0.5 * channel_width
-        ).to(U.m / U.s, equivalencies=U.doppler_radio(HIfreq)) - (
-            velocity_centre.to(
-                channel_width.unit, equivalencies=U.doppler_radio(HIfreq)
-            )
-            - 0.5 * channel_width
-        ).to(
-            U.m / U.s, equivalencies=U.doppler_radio(HIfreq)
+        self.channel_width = np.abs(
+            (
+                velocity_centre.to(
+                    channel_width.unit, equivalencies=U.doppler_radio(HIfreq)
+                )
+                + 0.5 * channel_width
+            ).to(U.m / U.s, equivalencies=U.doppler_radio(HIfreq))
+            - (
+                velocity_centre.to(
+                    channel_width.unit, equivalencies=U.doppler_radio(HIfreq)
+                )
+                - 0.5 * channel_width
+            ).to(U.m / U.s, equivalencies=U.doppler_radio(HIfreq))
         )
         self.ra = ra
         self.dec = dec
@@ -121,6 +122,7 @@ class DataCube(object):
             ),
         ]
         self.wcs.wcs.ctype = ["RA---TAN", "DEC--TAN", "VRAD"]
+        self.wcs.wcs.specsys = "GALACTOC"
         self.wcs = wcs.utils.add_stokes_axis_to_wcs(self.wcs, self.wcs.wcs.naxis)
         return
 

--- a/martini/martini.py
+++ b/martini/martini.py
@@ -470,7 +470,7 @@ class Martini:
         else:
             raise ValueError(
                 "Martini.write_fits: Unknown 'channels' value "
-                "(use 'frequency' or 'velocity'."
+                "(use 'frequency' or 'velocity')."
             )
 
         filename = filename if filename[-5:] == ".fits" else filename + ".fits"

--- a/tests/test_datacube.py
+++ b/tests/test_datacube.py
@@ -1,7 +1,6 @@
 import pytest
 import os
-import numpy as np
-from astropy import units as U, constants as C
+from astropy import units as U
 from martini import DataCube
 from martini.datacube import HIfreq
 
@@ -39,22 +38,16 @@ class TestDataCube:
         """
         Check that we can convert to frequency channels.
         """
-        v_mid0 = dc.channel_mids[0]
-        v_edge0 = dc.channel_edges[0]
-        v_mid1 = dc.channel_mids[-1]
-        v_edge1 = dc.channel_edges[-1]
-        f_mid0 = HIfreq * (1 - v_mid0 / C.c)
-        f_edge0 = HIfreq * (1 - v_edge0 / C.c)
-        f_mid1 = HIfreq * (1 - v_mid1 / C.c)
-        f_edge1 = HIfreq * (1 - v_edge1 / C.c)
+        v_channel_mids = dc.channel_mids
+        v_channel_edges = dc.channel_edges
         dc.freq_channels()
         assert U.allclose(
-            dc.channel_mids, np.linspace(f_mid0, f_mid1, dc.n_channels), atol=1 * U.Hz
+            dc.channel_mids.to(U.m / U.s, equivalencies=U.doppler_radio(HIfreq)),
+            v_channel_mids,
         )
         assert U.allclose(
-            dc.channel_edges,
-            np.linspace(f_edge0, f_edge1, dc.n_channels + 1),
-            atol=1 * U.Hz,
+            dc.channel_edges.to(U.m / U.s, equivalencies=U.doppler_radio(HIfreq)),
+            v_channel_edges,
         )
 
     def test_velocity_channels(self, dc):
@@ -62,24 +55,16 @@ class TestDataCube:
         Check that we can convert to velocity channels.
         """
         dc.freq_channels()
-        f_mid0 = dc.channel_mids[0]
-        f_edge0 = dc.channel_edges[0]
-        f_mid1 = dc.channel_mids[-1]
-        f_edge1 = dc.channel_edges[-1]
-        v_mid0 = C.c * (1 - f_mid0 / HIfreq)
-        v_edge0 = C.c * (1 - f_edge0 / HIfreq)
-        v_mid1 = C.c * (1 - f_mid1 / HIfreq)
-        v_edge1 = C.c * (1 - f_edge1 / HIfreq)
+        f_channel_mids = dc.channel_mids
+        f_channel_edges = dc.channel_edges
         dc.velocity_channels()
         assert U.allclose(
-            dc.channel_mids,
-            np.linspace(v_mid0, v_mid1, dc.n_channels),
-            atol=1e-3 * U.m / U.s,
+            dc.channel_mids.to(U.Hz, equivalencies=U.doppler_radio(HIfreq)),
+            f_channel_mids,
         )
         assert U.allclose(
-            dc.channel_edges,
-            np.linspace(v_edge0, v_edge1, dc.n_channels + 1),
-            atol=1e-3 * U.m / U.s,
+            dc.channel_edges.to(U.Hz, equivalencies=U.doppler_radio(HIfreq)),
+            f_channel_edges,
         )
 
     def test_channel_mode_switching(self, dc):
@@ -228,3 +213,17 @@ class TestDataCube:
             raise
         finally:
             os.remove("test_savestate.hdf5")
+
+    def test_init_with_frequency_channel_spec(self):
+        """
+        Check that we can specify channel spacing and central channel in frequency units.
+        """
+
+        # also check mixed case: freq width and vel centre, vice-versa
+        raise NotImplementedError
+
+    def test_channels_equal_in_frequency(self):
+        """
+        Expect channels to be equally spaced in frequency, check that this is the case.
+        """
+        raise NotImplementedError

--- a/tests/test_datacube.py
+++ b/tests/test_datacube.py
@@ -235,17 +235,17 @@ class TestDataCube:
         dc_vf = DataCube(
             velocity_centre=dc.velocity_centre,
             channel_width=f_channel_width,
-            **const_kwargs
+            **const_kwargs,
         )
         dc_fv = DataCube(
             velocity_centre=f_velocity_centre,
             channel_width=dc.channel_width,
-            **const_kwargs
+            **const_kwargs,
         )
         dc_ff = DataCube(
             velocity_centre=f_velocity_centre,
             channel_width=f_channel_width,
-            **const_kwargs
+            **const_kwargs,
         )
         assert U.allclose(dc_vf.channel_edges, dc.channel_edges)
         assert U.allclose(dc_fv.channel_edges, dc.channel_edges)

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -27,7 +27,7 @@ class TestWrite:
             m.write_fits(filename, channels="velocity")
             with fits.open(filename) as f:
                 hdr = f[0].header
-            assert "VOPT" in hdr["CTYPE3"]
+            assert hdr["CTYPE3"] == "VRAD"
         finally:
             if os.path.exists(filename):
                 os.remove(filename)
@@ -53,7 +53,7 @@ class TestWrite:
         try:
             m.write_hdf5(filename, channels="velocity")
             with h5py.File(filename, "r") as f:
-                assert f["FluxCube"].attrs["VProjType"] == "VOPT"
+                assert f["FluxCube"].attrs["VProjType"] == "VRAD"
         finally:
             if os.path.exists(filename):
                 os.remove(filename)
@@ -81,7 +81,7 @@ class TestWrite:
             m.write_beam_fits(filename, channels="velocity")
             with fits.open(filename) as f:
                 hdr = f[0].header
-            assert "VOPT" in hdr["CTYPE3"]
+            assert "VRAD" in hdr["CTYPE3"]
         finally:
             if os.path.exists(filename):
                 os.remove(filename)


### PR DESCRIPTION
Add support for initialising channels with a velocity centre and channel width given in either velocity or frequency units (in any combination). Implementing this also triggered a review of details of how channels are defined and converted back and forth between frequency and velocity. Now have consistent use of radio Doppler convention throughout and better test coverage, including asserting that channels are evenly spaced in frequency. Closes #22.