### PR TITLE
Add toggle option for DataCube Stokes' axis

### DIFF
--- a/examples/martini_eagle.ipynb
+++ b/examples/martini_eagle.ipynb
@@ -619,7 +619,6 @@
    "outputs": [],
    "source": [
     "FluxCube.shape\n",
-    "FluxCube = FluxCube[0]  # strip the Stokes' axis\n",
     "FluxCube.shape"
    ]
   },

--- a/examples/martini_simba.ipynb
+++ b/examples/martini_simba.ipynb
@@ -555,7 +555,6 @@
    "outputs": [],
    "source": [
     "FluxCube.shape\n",
-    "FluxCube = FluxCube[0]  # strip the Stokes' axis\n",
     "FluxCube.shape"
    ]
   },

--- a/martini/datacube.pyi
+++ b/martini/datacube.pyi
@@ -26,6 +26,7 @@ class DataCube:
     n_px_x: int
     n_px_y: int
     n_channels: int
+    stokes_axis: bool
 
     def __init__(
         self,
@@ -37,6 +38,7 @@ class DataCube:
         velocity_centre: U.Quantity[U.km / U.s] = ...,
         ra: U.Quantity[U.deg] = ...,
         dec: U.Quantity[U.deg] = ...,
+        stokes_axis: bool = ...,
     ) -> None: ...
     def spatial_slices(self) -> T.Iterator[U.Quantity]: ...
     def spectra(self) -> T.Iterator[U.Quantity]: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,13 +167,14 @@ def m_nn():
     yield m
 
 
-@pytest.fixture(scope="function")
-def dc():
+@pytest.fixture(scope="function", params=[True, False])
+def dc(request):
     dc = DataCube(
         n_px_x=16,
         n_px_y=16,
         n_channels=16,
         velocity_centre=3 * 70 * U.km / U.s,
+        stokes_axis=request.param,
     )
 
     dc._array[...] = (

--- a/tests/test_datacube.py
+++ b/tests/test_datacube.py
@@ -12,7 +12,8 @@ class TestDataCube:
         Check that dimensions are as requested.
         """
         datacube = DataCube(n_px_x=10, n_px_y=11, n_channels=12)
-        assert datacube._array.shape == (10, 11, 12, 1)
+        expected_shape = (10, 11, 12, 1) if datacube.stokes_axis else (10, 11, 12)
+        assert datacube._array.shape == expected_shape
 
     def test_channel_mids(self, dc):
         """
@@ -90,8 +91,9 @@ class TestDataCube:
             old_shape[0] + 2 * pad[0],
             old_shape[1] + 2 * pad[1],
             old_shape[2],
-            old_shape[3],
         )
+        if dc.stokes_axis:
+            expected_shape = expected_shape + (old_shape[3],)
         assert dc._array.shape == expected_shape
         assert dc.padx == pad[0]
         assert dc.pady == pad[1]
@@ -118,8 +120,9 @@ class TestDataCube:
             old_shape[0] - 2 * pad[0],
             old_shape[1] - 2 * pad[1],
             old_shape[2],
-            old_shape[3],
         )
+        if dc.stokes_axis:
+            expected_shape = expected_shape + (old_shape[3],)
         assert dc._array.shape == initial_shape
         assert dc._array.shape == expected_shape
         assert dc.padx == 0


### PR DESCRIPTION
The Stokes' axis in the DataCube usually serves no useful purpose and would be simpler to omit. This is now the default behaviour, but the axis can still be included by using the `DataCube(..., stokes_axis=True)` keyword argument. Closes #19 