### PR TITLE
Delay transformation of source coordinates

### DIFF
--- a/martini/sources/sph_source.pyi
+++ b/martini/sources/sph_source.pyi
@@ -1,5 +1,6 @@
 import astropy.units as U
 from astropy.coordinates import ICRS
+from martini.datacube import DataCube
 from numpy import ndarray
 import typing as T
 
@@ -40,6 +41,8 @@ class SPHSource:
         hsm_g: T.Optional[U.Quantity[U.kpc]] = ...,
         coordinate_axis: T.Optional[int] = ...,
     ) -> None: ...
+    def _init_skycoords(self, _reset: bool = ...) -> None: ...
+    def _init_pixcoords(self, datacube: DataCube, origin: int = ...) -> None: ...
     def apply_mask(self, mask: ndarray) -> None: ...
     def rotate(
         self,

--- a/martini/spectral_models.py
+++ b/martini/spectral_models.py
@@ -61,8 +61,8 @@ class _BaseSpectrum(metaclass=ABCMeta):
 
         channel_edges = datacube.channel_edges
         channel_widths = np.diff(channel_edges).to(U.km * U.s**-1)
-        vmids = source.sky_coordinates.radial_velocity
-        A = source.mHI_g * np.power(source.sky_coordinates.distance.to(U.Mpc), -2)
+        vmids = source.skycoords.radial_velocity
+        A = source.mHI_g * np.power(source.skycoords.distance.to(U.Mpc), -2)
         MHI_Jy = (
             U.Msun * U.Mpc**-2 * (U.km * U.s**-1) ** -1,
             U.Jy,
@@ -165,7 +165,7 @@ class _BaseSpectrum(metaclass=ABCMeta):
             k: np.tile(
                 v,
                 np.shape(datacube.channel_edges[:-1])
-                + (1,) * source.sky_coordinates.radial_velocity.ndim,
+                + (1,) * source.skycoords.radial_velocity.ndim,
             )
             .astype(self.spec_dtype)
             .T

--- a/martini/sph_kernels.py
+++ b/martini/sph_kernels.py
@@ -159,7 +159,7 @@ class _BaseSPHKernel(object):
         datacube : martini.DataCube instance
             The datacube providing the pixel scale.
         """
-        self.sm_lengths = np.arctan(source.hsm_g / source.sky_coordinates.distance).to(
+        self.sm_lengths = np.arctan(source.hsm_g / source.skycoords.distance).to(
             U.pix, U.pixel_scale(datacube.px_size / U.pix)
         )
 

--- a/tests/test_martini.py
+++ b/tests/test_martini.py
@@ -2,65 +2,15 @@ import os
 import pytest
 import numpy as np
 import h5py
-from martini.martini import Martini, _gen_particle_coords
+from martini.martini import Martini
 from martini.datacube import DataCube, HIfreq
 from martini.beams import GaussianBeam
-from martini.sources import SPHSource
 from test_sph_kernels import simple_kernels
 from martini.sph_kernels import CubicSplineKernel, GaussianKernel
 from martini.spectral_models import DiracDeltaSpectrum, GaussianSpectrum
 from astropy import units as U
 from astropy.io import fits
 from scipy.signal import fftconvolve
-
-
-class TestMartiniUtils:
-    def test_gen_particle_coords(self):
-        """
-        Check that pixel coordinates are accurately calculated from angular positions and
-        velocity offsets.
-        """
-        # set distance so that 1kpc = 1arcsec
-        distance = (1 * U.kpc / 1 / U.arcsec).to(U.Mpc, U.dimensionless_angles())
-        # line up particles 1 per 1kpc = 1arcsec interval in RA and Dec
-        # and 1 per 1 km / s interval in vlos
-        # set h=0 so that velocity stays centred at 0
-        source = SPHSource(
-            distance=distance,
-            h=0.0,
-            T_g=np.ones(5) * 1e4 * U.K,
-            mHI_g=np.ones(5) * 1e4 * U.Msun,
-            xyz_g=U.Quantity(
-                np.vstack(
-                    (
-                        np.zeros(6),
-                        np.linspace(-2.5, 2.5, 6),
-                        (np.linspace(-2.5, 2.5, 6)),
-                    )
-                ).T,
-                U.kpc,
-            ),
-            vxyz_g=U.Quantity(
-                np.vstack((np.linspace(-2.5, 2.5, 6), np.zeros(6), np.zeros(6))).T,
-                U.km / U.s,
-            ),
-            hsm_g=np.ones(6) * U.kpc,
-        )
-        datacube = DataCube(
-            n_px_x=6,
-            n_px_y=6,
-            n_channels=6,
-            px_size=1 * U.arcsec,
-            channel_width=1 * U.km / U.s,
-        )
-        expected_coords = (
-            np.vstack((np.arange(6)[::-1], np.arange(6), np.arange(6))) * U.pix
-        )
-        assert U.allclose(
-            _gen_particle_coords(source, datacube),
-            expected_coords,
-            atol=1e-4 * U.pix,
-        )
 
 
 class TestMartini:

--- a/tests/test_spectral_models.py
+++ b/tests/test_spectral_models.py
@@ -14,6 +14,7 @@ class TestGaussianSpectrum:
         Check that spectrum sums to expected flux.
         """
         source = single_particle_source(distance=1 * U.Mpc)  # D=1Mpc
+        source._init_skycoords()
         spectral_model = GaussianSpectrum(sigma=sigma)
         datacube = DataCube(
             n_channels=64, channel_width=4 * U.km / U.s, velocity_centre=source.vsys
@@ -49,6 +50,7 @@ class TestGaussianSpectrum:
         Check that spectral function gives a normalised spectrum.
         """
         source = single_particle_source()
+        source._init_skycoords()
         spectral_model = GaussianSpectrum(sigma=sigma)
         datacube = DataCube(
             n_channels=64, channel_width=4 * U.km / U.s, velocity_centre=source.vsys
@@ -68,6 +70,7 @@ class TestGaussianSpectrum:
         Check that required extra data is loaded: velocity dispersions.
         """
         source = request.getfixturevalue(source)()
+        source._init_skycoords()
         spectral_model = GaussianSpectrum(sigma=sigma)
         datacube = DataCube(
             n_channels=64, channel_width=4 * U.km / U.s, velocity_centre=source.vsys
@@ -87,6 +90,7 @@ class TestDiracDeltaSpectrum:
         Chec that spectrum sums to expected flux.
         """
         source = single_particle_source(distance=1 * U.Mpc)  # D=1Mpc
+        source._init_skycoords()
         spectral_model = DiracDeltaSpectrum()
         datacube = DataCube(
             n_channels=64, channel_width=4 * U.km / U.s, velocity_centre=source.vsys
@@ -111,6 +115,7 @@ class TestDiracDeltaSpectrum:
         Check that spectral function returns normalised spectrum.
         """
         source = single_particle_source()
+        source._init_skycoords()
         spectral_model = DiracDeltaSpectrum()
         datacube = DataCube(
             n_channels=64, channel_width=4 * U.km / U.s, velocity_centre=source.vsys
@@ -127,6 +132,7 @@ class TestDiracDeltaSpectrum:
         Check that no extra data is loaded.
         """
         source = single_particle_source()
+        source._init_skycoords()
         datacube = DataCube(
             n_channels=64, channel_width=4 * U.km / U.s, velocity_centre=source.vsys
         )
@@ -144,6 +150,7 @@ class TestSpectrumPrecision:
         Check that spectral model can use specified precision.
         """
         source = single_particle_source()
+        source._init_skycoords()
         spectral_model = SpectralModel(spec_dtype=dtype)
         datacube = DataCube()
         spectral_model.init_spectra(source, datacube)


### PR DESCRIPTION
Previously when a source module was initialised, the rotations and translations to bring the particles to the RA, Dec and distance needed to calculate sky coordinates were performed immediately. This precludes any inspection and manipulation of the source (e.g. rotating it to be face-on) before proceeding. Especially in cases where the particle arrays are retrieved automatically (e.g. EAGLESource, TNGSource, ...) this is very awkward as the user has no opportunity to inspect/manipulate the source. This PR moves the source rotations and translations for RA, Dec and distance to the initialisation of the Martini object, so the source object can be interacted with prior to passing it to the Martini class. Closes #25.