### PR TITLE
Use astropy beam_angular_area equivalency

### DIFF
--- a/martini/beams.py
+++ b/martini/beams.py
@@ -61,12 +61,7 @@ class _BaseBeam(object):
         # since bmaj, bmin are FWHM, need to include conversion to
         # gaussian-equivalent width (2sqrt(2log2)sigma = FWHM), and then
         # A = 2pi * sigma_maj * sigma_min = pi * b_maj * b_min / 4 / log2
-        self.arcsec_to_beam = (
-            U.Jy * U.arcsec**-2,
-            U.Jy * U.beam**-1,
-            lambda x: x * (np.pi * self.bmaj * self.bmin) / 4 / np.log(2),
-            lambda x: x / (np.pi * self.bmaj * self.bmin) * 4 * np.log(2),
-        )
+        self.area = (np.pi * self.bmaj * self.bmin) / 4 / np.log(2)
 
         return
 

--- a/martini/beams.pyi
+++ b/martini/beams.pyi
@@ -13,16 +13,7 @@ class _BaseBeam(metaclass=abc.ABCMeta):
     bpa: U.Quantity[U.deg]
     px_size: T.Optional[U.Quantity[U.arcsec]]
     kernel: T.Optional[U.Quantity[U.dimensionless_unscaled]]
-    arcsec_to_beam: T.Tuple[
-        U.Quantity[U.Jy * U.arcsec**-2],
-        U.Quantity[U.Jy * U.beam**-1],
-        T.Callable[
-            [U.Quantity[U.Jy * U.arcsec**-2]], U.Quantity[U.Jy * U.beam**-1]
-        ],
-        T.Callable[
-            [U.Quantity[U.Jy * U.beam**-1]], U.Quantity[U.Jy * U.arcsec**-2]
-        ],
-    ]
+    area: U.Quantity[U.arcsec**2]
 
     def __init__(
         self,

--- a/martini/martini.py
+++ b/martini/martini.py
@@ -19,7 +19,7 @@ try:
         cwd=os.path.dirname(os.path.realpath(__file__)),
     )
 except (subprocess.CalledProcessError, FileNotFoundError):
-    pass
+    gc = b""
 else:
     martini_version = martini_version + "_commit_" + gc.strip().decode()
 
@@ -256,7 +256,8 @@ class Martini:
             )
         self.datacube.drop_pad()
         self.datacube._array = self.datacube._array.to(
-            U.Jy * U.beam**-1, equivalencies=[self.beam.arcsec_to_beam]
+            U.Jy * U.beam**-1,
+            equivalencies=U.beam_angular_area(self.beam.area),
         )
         if not self.quiet:
             print(
@@ -284,7 +285,7 @@ class Martini:
             self.noise.generate(self.datacube, self.beam)
             .to(
                 U.Jy * U.arcsec**-2,
-                equivalencies=[self.beam.arcsec_to_beam],
+                equivalencies=U.beam_angular_area(self.beam.area),
             )
             .to(self.datacube._array.unit, equivalencies=[self.datacube.arcsec2_to_pix])
         )

--- a/tests/test_martini.py
+++ b/tests/test_martini.py
@@ -301,7 +301,8 @@ class TestMartini:
             m.datacube.padx : -m.datacube.padx, m.datacube.pady : -m.datacube.padx
         ]
         convolved_cube = convolved_cube.to(
-            U.Jy * U.beam**-1, equivalencies=[m.beam.arcsec_to_beam]
+            U.Jy * U.beam**-1,
+            equivalencies=U.beam_angular_area(m.beam.area),
         )
         m.convolve_beam()
         assert U.allclose(m.datacube._array, convolved_cube)
@@ -318,7 +319,8 @@ class TestMartini:
         assert U.allclose(
             m_init.datacube._array,
             expected_noise.to(
-                U.Jy * U.arcsec**-2, equivalencies=[m_init.beam.arcsec_to_beam]
+                U.Jy * U.arcsec**-2,
+                equivalencies=U.beam_angular_area(m_init.beam.area),
             ).to(
                 m_init.datacube._array.unit,
                 equivalencies=[m_init.datacube.arcsec2_to_pix],


### PR DESCRIPTION
Astropy provides a `astropy.unit.beam_angular_area` equivalency. Replaces use of my self-made equivalency where relevant. Considered doing the same for pixel area to pixel count conversion, but astropy only has linear pixel-to-arcsec equivalencies, and these won't convert `pix**2` and `arcsec**2`. Closes #29 