### PR TITLE
Tests and optional dependencies

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,7 @@ exclude =
 per-file-ignores = 
     martini/__init__.py:F401
     martini/sources/__init__.py:F401
+    tests/test_martini.py:F401
+    tests/test_datacube.py:F401
+    tests/test_sources.py:F401
+    tests/test_spectral_models.py:F401

--- a/tests/test_datacube.py
+++ b/tests/test_datacube.py
@@ -5,6 +5,13 @@ from astropy import units as U
 from martini import DataCube
 from martini.datacube import HIfreq
 
+try:
+    import h5py
+except ImportError:
+    have_h5py = False
+else:
+    have_h5py = True
+
 
 class TestDataCube:
     def test_datacube_dimensions(self):
@@ -175,6 +182,9 @@ class TestDataCube:
             assert U.allclose(getattr(dc_random, attr), getattr(copy, attr))
         assert str(dc_random.wcs) == str(copy.wcs)
 
+    @pytest.mark.skipif(
+        not have_h5py, reason="h5py (optional dependency) not available."
+    )
     @pytest.mark.parametrize("with_fchannels", (False, True))
     @pytest.mark.parametrize("with_pad", (False, True))
     def test_save_and_load_state(self, dc_random, with_fchannels, with_pad):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -9,6 +9,13 @@ from martini.sources._cartesian_translation import translate, translate_d
 from martini.sources._L_align import L_align
 from astropy.coordinates import CartesianRepresentation, CartesianDifferential
 
+try:
+    import matplotlib
+except ImportError:
+    have_matplotlib = False
+else:
+    have_matplotlib = True
+
 
 class TestSourceUtilities:
     def test_L_align(self):
@@ -449,6 +456,9 @@ class TestSPHSource:
                 os.remove(testfile)
         assert np.allclose(saved_rotmat, rotmat)
 
+    @pytest.mark.skipif(
+        not have_matplotlib, reason="matplotlib (optional dependency) not available."
+    )
     def test_preview(self, s):
         """
         Simply check that the preview visualisation runs without error.
@@ -465,6 +475,9 @@ class TestSPHSource:
             title="test",
         )
 
+    @pytest.mark.skipif(
+        not have_matplotlib, reason="matplotlib (optional dependency) not available."
+    )
     @pytest.mark.parametrize("ext", ("pdf", "png"))
     def test_preview_save(self, s, ext):
         """

--- a/tests/test_spectral_models.py
+++ b/tests/test_spectral_models.py
@@ -4,6 +4,13 @@ from martini import DataCube
 from martini.spectral_models import GaussianSpectrum, DiracDeltaSpectrum
 from astropy import units as U
 
+try:
+    import multiprocess
+except ImportError:
+    have_multiprocess = False
+else:
+    have_multiprocess = True
+
 spectral_models = GaussianSpectrum, DiracDeltaSpectrum
 
 
@@ -157,6 +164,9 @@ class TestSpectrumPrecision:
         assert spectral_model.spectra.dtype == dtype
 
 
+@pytest.mark.skipif(
+    not have_multiprocess, reason="multiprocess (optional dependency) not available."
+)
 class TestParallelSpectra:
     @pytest.mark.parametrize("SpectralModel", spectral_models)
     def test_parallel_spectra(self, SpectralModel, cross_source):

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,9 +1,16 @@
+import pytest
 import os
 from astropy.io import fits
-import h5py
+
+try:
+    import h5py
+except ImportError:
+    have_h5py = False
+else:
+    have_h5py = True
 
 
-class TestWrite:
+class TestWriteFits:
     def test_write_fits_freqchannels(self, m):
         """
         Check that fits cube gets written with frequency channels.
@@ -32,32 +39,6 @@ class TestWrite:
             if os.path.exists(filename):
                 os.remove(filename)
 
-    def test_write_hdf5_freqchannels(self, m):
-        """
-        Check that hdf5 cube gets written with frequency channels.
-        """
-        filename = "cube_f.hdf5"
-        try:
-            m.write_hdf5(filename, channels="frequency")
-            with h5py.File(filename, "r") as f:
-                assert f["FluxCube"].attrs["VProjType"] == "FREQ"
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
-    def test_write_hdf5_velchannels(self, m):
-        """
-        Check that hdf5 cube gets written with velocity channels.
-        """
-        filename = "cube_v.hdf5"
-        try:
-            m.write_hdf5(filename, channels="velocity")
-            with h5py.File(filename, "r") as f:
-                assert f["FluxCube"].attrs["VProjType"] == "VRAD"
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
     def test_write_fits_beam_freqchannels(self, m):
         """
         Check that fits beam cube gets written with frequency channels.
@@ -82,6 +63,36 @@ class TestWrite:
             with fits.open(filename) as f:
                 hdr = f[0].header
             assert "VRAD" in hdr["CTYPE3"]
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+
+@pytest.mark.skipif(not have_h5py, reason="h5py (optional dependency) not available.")
+class TestWriteHDF5:
+
+    def test_write_hdf5_freqchannels(self, m):
+        """
+        Check that hdf5 cube gets written with frequency channels.
+        """
+        filename = "cube_f.hdf5"
+        try:
+            m.write_hdf5(filename, channels="frequency")
+            with h5py.File(filename, "r") as f:
+                assert f["FluxCube"].attrs["VProjType"] == "FREQ"
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_write_hdf5_velchannels(self, m):
+        """
+        Check that hdf5 cube gets written with velocity channels.
+        """
+        filename = "cube_v.hdf5"
+        try:
+            m.write_hdf5(filename, channels="velocity")
+            with h5py.File(filename, "r") as f:
+                assert f["FluxCube"].attrs["VProjType"] == "VRAD"
         finally:
             if os.path.exists(filename):
                 os.remove(filename)


### PR DESCRIPTION
Some tests rely on optional dependencies (h5py, matplotlib, multiprocess). Add some checks to skip these tests if the individual optional dependencies are not installed.