### PR TITLE
Tests for example notebooks

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -73,11 +73,9 @@ jobs:
         pip install -e .
     - name: Test with pytest
       env:
-        VAR1: 999
         TNG_API_KEY: ${{ secrets.TNG_API_KEY }}
       run: |
-        env
-        pytest -k test_tng_notebook
+        pytest
 
   tests-and-coverage:
     needs: lint
@@ -104,7 +102,10 @@ jobs:
         if [ -f optional_requirements.txt ]; then pip install -r optional_requirements.txt; fi
         pip install -e .
     - name: Test with pytest including coverage report
-      run: pytest --cov=./ --cov-report=xml
+      env:
+        TNG_API_KEY: ${{ secrets.TNG_API_KEY }}
+      run: |
+        pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       env:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -73,7 +73,7 @@ jobs:
         pip install -e .
     - name: Test with pytest
       env:
-	TNG_API_KEY: ${{ secrets.TNG_API_KEY }}
+        TNG_API_KEY: ${{ secrets.TNG_API_KEY }}
       run: pytest
 
   tests-and-coverage:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -77,7 +77,7 @@ jobs:
         TNG_API_KEY=${{ secrets.TNG_API_KEY }}
       run: |
         env
-	pytest -k test_tng_notebook
+        pytest -k test_tng_notebook
 
   tests-and-coverage:
     needs: lint

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -72,9 +72,7 @@ jobs:
         if [ -f optional_requirements.txt ]; then pip install -r optional_requirements.txt; fi
         pip install -e .
     - name: Test with pytest
-      env:
-        TNG_API_KEY: ${{ secrets.TNG_API_KEY }}
-      run: pytest
+      run: TNG_API_KEY=${{ secrets.TNG_API_KEY }} pytest
 
   tests-and-coverage:
     needs: lint

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -73,8 +73,8 @@ jobs:
         pip install -e .
     - name: Test with pytest
       env:
-        VAR1=999
-        TNG_API_KEY=${{ secrets.TNG_API_KEY }}
+        VAR1: 999
+        TNG_API_KEY: ${{ secrets.TNG_API_KEY }}
       run: |
         env
         pytest -k test_tng_notebook

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -72,7 +72,12 @@ jobs:
         if [ -f optional_requirements.txt ]; then pip install -r optional_requirements.txt; fi
         pip install -e .
     - name: Test with pytest
-      run: TNG_API_KEY=${{ secrets.TNG_API_KEY }} pytest
+      env:
+        VAR1=999
+        TNG_API_KEY=${{ secrets.TNG_API_KEY }}
+      run: |
+        env
+	pytest -k test_tng_notebook
 
   tests-and-coverage:
     needs: lint

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -72,6 +72,8 @@ jobs:
         if [ -f optional_requirements.txt ]; then pip install -r optional_requirements.txt; fi
         pip install -e .
     - name: Test with pytest
+      env:
+	TNG_API_KEY: ${{ secrets.TNG_API_KEY }}
       run: pytest
 
   tests-and-coverage:

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ examples/*.npy
 examples/*.tar
 examples/sql_cookies.txt
 examples/eagle_db.password
+examples/tng_api.key
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ examples/*.hdf5
 examples/*.npy
 examples/*.tar
 examples/sql_cookies.txt
+examples/eagle_db.password
 .coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         target: 100%
-	threshold: 10%
+        threshold: 10%
 ignore:
   - "tests"
   - "docs"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+	threshold: 10%
+ignore:
+  - "tests"
+  - "docs"
+  - "martini/sources/_illustris_tools.py"
+  - "martini/sources/tng_source.py"
+  - "martini/sources/eagle_source.py"
+  - "martini/sources/simba_source.py"

--- a/examples/martini_TNG.ipynb
+++ b/examples/martini_TNG.ipynb
@@ -49,7 +49,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "import sys\n",
@@ -156,7 +160,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "from getpass import getpass\n",
@@ -174,7 +182,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "nbmake": {
+       "mock": {
+         "api_key": 0,
+	 "config": "/test/config.json",
+	 "args": {
+	   "env": "test"
+	 }
+       }
+     }
+   },
    "outputs": [],
    "source": [
     "simulation = \"TNG100-1\"\n",

--- a/examples/martini_TNG.ipynb
+++ b/examples/martini_TNG.ipynb
@@ -237,7 +237,8 @@
     "from martini.noise import GaussianNoise\n",
     "from martini.spectral_models import GaussianSpectrum\n",
     "from martini.sph_kernels import CubicSplineKernel\n",
-    "import astropy.units as U"
+    "import astropy.units as U\n",
+    "import numpy as np",
    ]
   },
   {

--- a/examples/martini_TNG.ipynb
+++ b/examples/martini_TNG.ipynb
@@ -74,7 +74,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "!{sys.executable} -m pip install matplotlib"
@@ -124,7 +128,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "from martini import demo\n",

--- a/examples/martini_TNG.ipynb
+++ b/examples/martini_TNG.ipynb
@@ -238,7 +238,7 @@
     "from martini.spectral_models import GaussianSpectrum\n",
     "from martini.sph_kernels import CubicSplineKernel\n",
     "import astropy.units as U\n",
-    "import numpy as np",
+    "import numpy as np"
    ]
   },
   {

--- a/examples/martini_TNG.ipynb
+++ b/examples/martini_TNG.ipynb
@@ -193,6 +193,7 @@
    "metadata": {
      "nbmake": {
        "post_cell_execute": [
+         "import os",
          "try:",
 	 "    api_key = os.environ['TNG_API_KEY']",
 	 "except KeyError:  # running locally",

--- a/examples/martini_TNG.ipynb
+++ b/examples/martini_TNG.ipynb
@@ -50,9 +50,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -75,9 +75,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -129,9 +129,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -169,9 +169,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -191,16 +191,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "nbmake": {
-       "post_cell_execute": [
-         "import os",
-         "try:",
-	 "    api_key = os.environ['TNG_API_KEY']",
-	 "except KeyError:  # running locally",
-	 "    with open('tng_api.key') as f:",
-         "        api_key = f.read()"
-       ]
-     }
+    "nbmake": {
+     "post_cell_execute": [
+      "import os",
+      "try:",
+      "    api_key = os.environ['TNG_API_KEY']",
+      "except KeyError:  # running locally",
+      "    with open('tng_api.key') as f:",
+      "        api_key = f.read()"
+     ]
+    }
    },
    "outputs": [],
    "source": [
@@ -578,6 +578,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The main source insertion loop, that is the most computationally demanding step, can be run in parallel if the `multiprocess` package is installed (not to be confused with `multiprocessing`, which is normally included with python!). Edit the cell below to use more than 1 CPU core if this package is installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbmake": {
+     "post_cell_execute": [
+      "ncpu = 8"
+     ]
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ncpu = 1  # can be >1 if multiprocess package is installed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "If we're happy with the preview, we're ready to call the functions to make the actual mock observation."
    ]
   },
@@ -587,7 +609,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "M.insert_source_in_cube()\n",
+    "M.insert_source_in_cube(ncpu=ncpu)\n",
     "M.add_noise()\n",
     "M.convolve_beam()"
    ]
@@ -596,8 +618,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The main source insertion loop, that is the most computationally demanding step, can be run in parallel if the `multiprocess` package is installed (not to be confused with `multiprocessing`, which is normally included with python!). Simply use `M.insert_source_in_cube(ncpu=N)`, where `N` is the number of processes to run in parallel.\n",
-    "\n",
     "You may notice that the number of pixels in the progress counter differs from the number defined in the DataCube module. This is because convolution with the beam requires some padding, which is ultimately filled with nonsense and discarded.\n",
     "\n",
     "To write the results: two output formats are available, depending on preference. Both\n",
@@ -1004,7 +1024,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0rc1"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/examples/martini_TNG.ipynb
+++ b/examples/martini_TNG.ipynb
@@ -192,13 +192,13 @@
    "execution_count": null,
    "metadata": {
      "nbmake": {
-       "mock": {
-         "api_key": 0,
-	 "config": "/test/config.json",
-	 "args": {
-	   "env": "test"
-	 }
-       }
+       "post_cell_execute": [
+         "try:",
+	 "    api_key = os.environ['TNG_API_KEY']",
+	 "except KeyError:  # running locally",
+	 "    with open('tng_api.key') as f:",
+         "        api_key = f.read()"
+       ]
      }
    },
    "outputs": [],

--- a/examples/martini_eagle.ipynb
+++ b/examples/martini_eagle.ipynb
@@ -43,9 +43,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -68,9 +68,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -122,9 +122,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -160,9 +160,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -237,14 +237,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "nbmake": {
-       "post_cell_execute": [
-         "username = \"jdw115\"",
-         "f = open(\"eagle_db.password\")",
-	 "password = f.read()",
-	 "f.close()"
-       ]
-     }
+    "nbmake": {
+     "post_cell_execute": [
+      "username = \"jdw115\"",
+      "f = open(\"eagle_db.password\")",
+      "password = f.read()",
+      "f.close()"
+     ]
+    }
    },
    "outputs": [],
    "source": [
@@ -759,7 +759,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FluxCube.shape"
+    "flux_cube.shape"
    ]
   },
   {

--- a/examples/martini_eagle.ipynb
+++ b/examples/martini_eagle.ipynb
@@ -236,7 +236,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "nbmake": {
+       "post_cell_execute": [
+         "username = \"jdw115\"",
+         "f = open(\"eagle_db.password\")",
+	 "password = f.read()",
+	 "f.close()"
+       ]
+     }
+   },
    "outputs": [],
    "source": [
     "snappath = \"RefL0025N0376/snapshot_028_z000p000\"\n",

--- a/examples/martini_eagle.ipynb
+++ b/examples/martini_eagle.ipynb
@@ -42,7 +42,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "import sys\n",
@@ -63,7 +67,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "!{sys.executable} -m pip install requests matplotlib"
@@ -113,7 +121,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "from martini import demo\n",
@@ -147,7 +159,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "from getpass import getpass\n",

--- a/examples/martini_eagle.ipynb
+++ b/examples/martini_eagle.ipynb
@@ -680,6 +680,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The main source insertion loop, that is the most computationally demanding step, can be run in parallel if the `multiprocess` package is installed (not to be confused with `multiprocessing`, which is normally included with python!). Edit the cell below to use more than 1 CPU core if this package is installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbmake": {
+     "post_cell_execute": [
+      "ncpu = 8"
+     ]
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ncpu = 1  # can be >1 if multiprocess package is installed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "If we're happy with the preview, we're ready to call the functions to make the actual mock observation."
    ]
   },
@@ -689,7 +711,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "M.insert_source_in_cube()\n",
+    "M.insert_source_in_cube(ncpu=ncpu)\n",
     "M.add_noise()\n",
     "M.convolve_beam()"
    ]
@@ -698,8 +720,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The main source insertion loop, that is the most computationally demanding step, can be run in parallel if the `multiprocess` package is installed (not to be confused with `multiprocessing`, which is normally included with python!). Simply use `M.insert_source_in_cube(ncpu=N)`, where `N` is the number of processes to run in parallel. \n",
-    "\n",
     "You may notice that the number of pixels in the progress counter differs from the number defined in the DataCube module. This is because convolution with the beam requires some padding, which is ultimately filled with nonsense and discarded.\n",
     "\n",
     "To write the results: two output formats are available, depending on preference. Both\n",
@@ -1104,7 +1124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0rc1"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/examples/martini_simba.ipynb
+++ b/examples/martini_simba.ipynb
@@ -607,6 +607,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The main source insertion loop, that is the most computationally demanding step, can be run in parallel if the `multiprocess` package is installed (not to be confused with `multiprocessing`, which is normally included with python!). Edit the cell below to use more than 1 CPU core if this package is installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbmake": {
+     "post_cell_execute": [
+      "ncpu = 8"
+     ]
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ncpu = 1  # can be >1 if multiprocess package is installed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "If we're happy with the preview, we're ready to call the functions to make the actual mock observation."
    ]
   },
@@ -616,7 +638,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "M.insert_source_in_cube()\n",
+    "M.insert_source_in_cube(ncpu=ncpu)\n",
     "M.add_noise()\n",
     "M.convolve_beam()"
    ]
@@ -625,8 +647,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The main source insertion loop, that is the most computationally demanding step, can be run in parallel if the `multiprocess` package is installed (not to be confused with `multiprocessing`, which is normally included with python!). Simply use `M.insert_source_in_cube(ncpu=N)`, where `N` is the number of processes to run in parallel.\n",
-    "\n",
     "You may notice that the number of pixels in the progress counter differs from the number defined in the DataCube module. This is because convolution with the beam requires some padding, which is ultimately filled with nonsense and discarded.\n",
     "\n",
     "To write the results: two output formats are available, depending on preference. Both\n",
@@ -1033,7 +1053,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0rc1"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/examples/martini_simba.ipynb
+++ b/examples/martini_simba.ipynb
@@ -43,9 +43,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -68,9 +68,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -122,9 +122,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-     "tags": [
-       "skip-execution"
-     ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -655,11 +655,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
+   "metadata": {},
    "source": [
     "Let's load the FITS file that MARTINI produced and take a quick look."
    ]

--- a/examples/martini_simba.ipynb
+++ b/examples/martini_simba.ipynb
@@ -42,7 +42,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "import sys\n",
@@ -63,7 +67,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "!{sys.executable} -m pip install requests matplotlib"
@@ -113,7 +121,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "skip-execution"
+     ]
+   },
    "outputs": [],
    "source": [
     "from martini import demo\n",

--- a/examples/martini_source_injection.ipynb
+++ b/examples/martini_source_injection.ipynb
@@ -45,7 +45,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
    "outputs": [],
    "source": [
     "import sys\n",
@@ -84,7 +88,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
    "outputs": [],
    "source": [
     "from getpass import getpass\n",
@@ -102,7 +110,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "nbmake": {
+     "post_cell_execute": [
+      "import os",
+      "try:",
+      "    api_key = os.environ['TNG_API_KEY']",
+      "except KeyError:  # running locally",
+      "    with open('tng_api.key') as f:",
+      "        api_key = f.read()"
+     ]
+    }
+   },
    "outputs": [],
    "source": [
     "simulation = \"TNG50-1\"\n",
@@ -417,8 +436,28 @@
    "source": [
     "The reason that we got a message saying that some particles were removed is clear: our galaxy extends past the edge of the cube. This isn't a problem, perhaps this \"galaxy\" that wasn't the main target of the observation happened to straddle the boundary of the field of view.\n",
     "\n",
-    "Next we run the bulk of the work of inserting the source into the datacube and the convolution of the beam. On a single CPU the source insertion step could take quite a while (hours?), so running this in parallel is recommended if you have a multi-core CPU. Just edit ``M.insert_source_in_cube(ncpu=8)`` specifying the number of cores that you wish to use. My 24-core setup runs this in a couple of minutes.\n",
-    "\n",
+    "Next we run the bulk of the work of inserting the source into the datacube and the convolution of the beam. On a single CPU the source insertion step could take quite a while (hours?), so running this in parallel is recommended if you have a multi-core CPU. Just edit the following cell specifying the number of cores that you wish to use. My 32-core setup runs the insertion in a couple of minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbmake": {
+     "post_cell_execute": [
+      "ncpu = 24"
+     ]
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ncpu = 1  # can set >1 if multiprocess is installed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "By default a progress bar (provided by ``tqdm``) will be displayed. This can be a bit glitchy on notebooks, especially when running on multiple cores, you can disable it with ``M.insert_source_in_cube(progressbar=False)``.\n",
     "\n",
     "The beam convolution step is relatively inexpensive.\n",
@@ -434,7 +473,7 @@
    "source": [
     "martini_cube_file = \"sourceinjectiondemo.fits\"\n",
     "if not os.path.isfile(martini_cube_file):\n",
-    "    M.insert_source_in_cube()  # this'll take a while\n",
+    "    M.insert_source_in_cube(ncpu=ncpu)  # this could take a while\n",
     "    M.convolve_beam()\n",
     "    M.write_fits(martini_cube_file)"
    ]
@@ -464,7 +503,7 @@
     "with fits.open(\"NGC_2841_NA_CUBE_THINGS.FITS\") as fitsfile:\n",
     "    ngc2841_header = fitsfile[0].header\n",
     "    ngc2841_cube = fitsfile[0].data\n",
-    "with fits.open(\"sourceinjectiondemo.fits\") as fitsfile:\n",
+    "with fits.open(martini_cube_file) as fitsfile:\n",
     "    martini_header = fitsfile[0].header\n",
     "    martini_cube = fitsfile[0].data.transpose((0, 1, 2, 3))  # this transpose: no effect"
    ]
@@ -577,7 +616,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0rc1"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -11,3 +11,4 @@ swiftgalaxy
 g3t
 pytest-cov
 numpydoc
+nbmake

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,51 @@
+import os
+from martini.__version__ import __version__
+import pytest
+
+
+class TestExamples:
+    def test_source_injection_example_version(self):
+        """
+        Check that the source injection notebook installs current version of martini.
+        """
+        with open("examples/martini_source_injection.ipynb") as f:
+            nb_content = f.read()
+        assert (
+            '"!{sys.executable} -m pip install "astromartini[tngsource]=='
+            + __version__
+            + '"'
+            in nb_content
+        )
+
+    @pytest.mark.skipif(
+        not os.path.isfile("examples/NGC_2841_NA_CUBE_THINGS.FITS"),
+        reason="sample data not locally available",
+    )
+    def test_source_injection_example(self):
+        pytest.importorskip(
+            "nbmake", reason="nbmake (optional dependency) not available"
+        )
+        from nbmake.nb_run import NotebookRun
+        from nbmake.pytest_items import NotebookFailedException
+        import pathlib
+
+        files_to_cleanup = (
+            "examples/NGC_2841_AND_TNG50-1_99_737963.FITS",
+            "examples/sourceinjectiondemo.fits",
+            "examples/martini-cutout-grnr-TNG50-1-99-737963.npy",
+            "examples/martini-cutout-TNG50-1-99-2122.hdf5",
+        )
+
+        assert os.path.isfile("examples/NGC_2841_NA_CUBE_THINGS.FITS")
+        for file_to_cleanup in files_to_cleanup:
+            if os.path.isfile(file_to_cleanup):
+                os.remove(file_to_cleanup)
+        nbr = NotebookRun(pathlib.Path("examples/martini_source_injection.ipynb"), 3600)
+        try:
+            result = nbr.execute()
+            if result.error is not None:
+                raise NotebookFailedException(result)
+        finally:
+            for file_to_cleanup in files_to_cleanup:
+                if os.path.isfile(file_to_cleanup):
+                    os.remove(file_to_cleanup)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -10,10 +10,11 @@ class TestExamples:
         """
         with open("examples/martini_source_injection.ipynb") as f:
             nb_content = f.read()
+        print(nb_content)
         assert (
-            '"!{sys.executable} -m pip install "astromartini[tngsource]=='
+            '"!{sys.executable} -m pip install \\"astromartini[tngsource]=='
             + __version__
-            + '"'
+            + '\\"'
             in nb_content
         )
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -8,6 +8,7 @@ from martini.sources import SPHSource
 from martini.sources._cartesian_translation import translate, translate_d
 from martini.sources._L_align import L_align
 from astropy.coordinates import CartesianRepresentation, CartesianDifferential
+from martini.__version__ import __version__
 
 
 class TestSourceUtilities:
@@ -496,11 +497,24 @@ class TestSPHSource:
                 os.remove(testfile)
 
 
-@pytest.mark.skipif(
-    not os.path.isdir("examples/RefL0025N0376"),
-    reason="sample data not locally available",
-)
 class TestEagleSource:
+    def test_notebook_version(self):
+        """
+        Check that notebook installs current verison of martini.
+        """
+        with open("examples/martini_eagle.ipynb") as f:
+            nb_content = f.read()
+        assert (
+            '"!{sys.executable} -m pip install \\"astromartini[eaglesource]=='
+            + __version__
+            + '\\""'
+            in nb_content
+        )
+
+    @pytest.mark.skipif(
+        not os.path.isdir("examples/RefL0025N0376"),
+        reason="sample data not locally available",
+    )
     def test_eagle_notebook(self):
         """
         Check that the EAGLE example notebook runs.
@@ -529,15 +543,25 @@ class TestEagleSource:
                     os.remove(file_to_cleanup)
 
 
-@pytest.mark.skipif(
-    not os.path.isfile("examples/m25n512_151.hdf5"),
-    reason="sample data not locally available",
-)
-@pytest.mark.skipif(
-    not os.path.isfile("examples/snap_m25n512_151.hdf5"),
-    reason="sample data not locally available",
-)
 class TestSimbaSource:
+    def test_notebook_version(self):
+        """
+        Check that notebook installs current verison of martini.
+        """
+        with open("examples/martini_simba.ipynb") as f:
+            nb_content = f.read()
+        assert (
+            '"!{sys.executable} -m pip install \\"astromartini[simbasource]=='
+            + __version__
+            + '\\""'
+            in nb_content
+        )
+
+    @pytest.mark.skipif(
+        not os.path.isfile("examples/m25n512_151.hdf5")
+        or not os.path.isfile("examples/snap_m25n512_151.hdf5"),
+        reason="sample data not locally available",
+    )
     def test_simba_notebook(self):
         """
         Check that the Simba example notebook runs.
@@ -565,15 +589,25 @@ class TestSimbaSource:
                     os.remove(file_to_cleanup)
 
 
-@pytest.mark.skipif(
-    not os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy"),
-    reason="sample data not locally available",
-)
-@pytest.mark.skipif(
-    not os.path.isfile("examples/martini-cutout-TNG100-1-99-517.hdf5"),
-    reason="sample data not locally available",
-)
 class TestTNGSource:
+    def test_notebook_version(self):
+        """
+        Check that notebook installs current verison of martini.
+        """
+        with open("examples/martini_TNG.ipynb") as f:
+            nb_content = f.read()
+        assert (
+            '"!{sys.executable} -m pip install \\"astromartini[tngsource]=='
+            + __version__
+            + '\\""'
+            in nb_content
+        )
+
+    @pytest.mark.skipif(
+        not os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy")
+        or not os.path.isfile("examples/martini-cutout-TNG100-1-99-517.hdf5"),
+        reason="sample data not locally available",
+    )
     def test_tng_notebook(self):
         """
         Check that the TNG example notebook runs.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -614,6 +614,9 @@ class TestTNGSource:
         from nbmake.pytest_items import NotebookFailedException
         import pathlib
 
+        print(os.environ)
+        print("VAR1", os.environ["VAR1"])
+        print("TNG_API_KEY", os.environ["TNG_API_KEY"])
         assert "TNG_API_KEY" in os.environ or os.path.isfile("examples/tng_api.key")
 
         if os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy"):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -615,7 +615,6 @@ class TestTNGSource:
         import pathlib
 
         print(os.environ)
-        print("VAR1", os.environ["VAR1"])
         print("TNG_API_KEY", os.environ["TNG_API_KEY"])
         assert "TNG_API_KEY" in os.environ or os.path.isfile("examples/tng_api.key")
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -532,7 +532,30 @@ class TestSimbaSource:
         raise NotImplementedError
 
 
+@pytest.mark.skipif(
+    not os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy")
+)
+@pytest.mark.skipif(not os.path.isfile("examples/martini-cutout-TNG100-1-99-517.npy"))
 class TestTNGSource:
-    @pytest.mark.xfail
-    def test_stuff(self):
-        raise NotImplementedError
+    def test_tng_notebook(self):
+        pytest.importorskip(
+            "nbmake", reason="nbmake (optional dependency) not available"
+        )
+        from nbmake.nb_run import NotebookRun
+        from nbmake.pytest_items import NotebookFailedException
+        import pathlib
+
+        nbr = NotebookRun(pathlib.Path("examples/martini_TNG.ipynb"), 3600)
+        try:
+            result = nbr.execute()
+            if result.error is not None:
+                raise NotebookFailedException(result)
+        finally:
+            files_to_cleanup = (
+                "examples/tng_martini_demo_beam.fits",
+                "examples/tng_martini_demo.fits",
+                "examples/tng_martini_demo.hdf5",
+            )
+            for file_to_cleanup in files_to_cleanup:
+                if os.path.isfile(file_to_cleanup):
+                    os.remove(file_to_cleanup)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -500,7 +500,6 @@ class TestSPHSource:
     not os.path.isdir("examples/RefL0025N0376"),
     reason="sample data not locally available",
 )
-@pytest.mark.skip  # until we figure out how to deal with db password
 class TestEagleSource:
     def test_eagle_notebook(self):
         """
@@ -513,6 +512,7 @@ class TestEagleSource:
         from nbmake.pytest_items import NotebookFailedException
         import pathlib
 
+        assert os.path.isfile("examples/eagle_db.password")
         nbr = NotebookRun(pathlib.Path("examples/martini_eagle.ipynb"), 3600)
         try:
             result = nbr.execute()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -496,40 +496,73 @@ class TestSPHSource:
                 os.remove(testfile)
 
 
-class TestSOSource:
-    @pytest.mark.xfail
-    def test_stuff(self):
-        raise NotImplementedError
-
-
-class TestSWIFTGalaxySource:
-    @pytest.mark.xfail
-    def test_stuff(self):
-        raise NotImplementedError
-
-
-class TestColibreSource:
-    @pytest.mark.xfail
-    def test_stuff(self):
-        raise NotImplementedError
-
-
+@pytest.mark.skipif(
+    not os.path.isdir("examples/RefL0025N0376"),
+    reason="sample data not locally available",
+)
+@pytest.mark.skip  # until we figure out how to deal with db password
 class TestEagleSource:
-    @pytest.mark.xfail
-    def test_stuff(self):
-        raise NotImplementedError
+    def test_eagle_notebook(self):
+        """
+        Check that the EAGLE example notebook runs.
+        """
+        pytest.importorskip(
+            "nbmake", reason="nbmake (optional dependency) not available"
+        )
+        from nbmake.nb_run import NotebookRun
+        from nbmake.pytest_items import NotebookFailedException
+        import pathlib
+
+        nbr = NotebookRun(pathlib.Path("examples/martini_eagle.ipynb"), 3600)
+        try:
+            result = nbr.execute()
+            if result.error is not None:
+                raise NotebookFailedException(result)
+        finally:
+            files_to_cleanup = (
+                "examples/eagle_martini_demo_beam.fits",
+                "examples/eagle_martini_demo.fits",
+                "examples/eagle_martini_demo.hdf5",
+            )
+            for file_to_cleanup in files_to_cleanup:
+                if os.path.isfile(file_to_cleanup):
+                    os.remove(file_to_cleanup)
 
 
-class TestMagneticumSource:
-    @pytest.mark.xfail
-    def test_stuff(self):
-        raise NotImplementedError
-
-
+@pytest.mark.skipif(
+    not os.path.isfile("examples/m25n512_151.hdf5"),
+    reason="sample data not locally available",
+)
+@pytest.mark.skipif(
+    not os.path.isfile("examples/snap_m25n512_151.hdf5"),
+    reason="sample data not locally available",
+)
 class TestSimbaSource:
-    @pytest.mark.xfail
-    def test_stuff(self):
-        raise NotImplementedError
+    def test_simba_notebook(self):
+        """
+        Check that the Simba example notebook runs.
+        """
+        pytest.importorskip(
+            "nbmake", reason="nbmake (optional dependency) not available"
+        )
+        from nbmake.nb_run import NotebookRun
+        from nbmake.pytest_items import NotebookFailedException
+        import pathlib
+
+        nbr = NotebookRun(pathlib.Path("examples/martini_simba.ipynb"), 3600)
+        try:
+            result = nbr.execute()
+            if result.error is not None:
+                raise NotebookFailedException(result)
+        finally:
+            files_to_cleanup = (
+                "examples/simba_martini_demo_beam.fits",
+                "examples/simba_martini_demo.fits",
+                "examples/simba_martini_demo.hdf5",
+            )
+            for file_to_cleanup in files_to_cleanup:
+                if os.path.isfile(file_to_cleanup):
+                    os.remove(file_to_cleanup)
 
 
 @pytest.mark.skipif(
@@ -542,6 +575,9 @@ class TestSimbaSource:
 )
 class TestTNGSource:
     def test_tng_notebook(self):
+        """
+        Check that the TNG example notebook runs.
+        """
         pytest.importorskip(
             "nbmake", reason="nbmake (optional dependency) not available"
         )
@@ -563,3 +599,27 @@ class TestTNGSource:
             for file_to_cleanup in files_to_cleanup:
                 if os.path.isfile(file_to_cleanup):
                     os.remove(file_to_cleanup)
+
+
+class TestMagneticumSource:
+    @pytest.mark.xfail
+    def test_stuff(self):
+        raise NotImplementedError
+
+
+class TestSOSource:
+    @pytest.mark.xfail
+    def test_stuff(self):
+        raise NotImplementedError
+
+
+class TestSWIFTGalaxySource:
+    @pytest.mark.xfail
+    def test_stuff(self):
+        raise NotImplementedError
+
+
+class TestColibreSource:
+    @pytest.mark.xfail
+    def test_stuff(self):
+        raise NotImplementedError

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -614,8 +614,6 @@ class TestTNGSource:
         from nbmake.pytest_items import NotebookFailedException
         import pathlib
 
-        print(os.environ)
-        print("TNG_API_KEY", os.environ["TNG_API_KEY"])
         assert "TNG_API_KEY" in os.environ or os.path.isfile("examples/tng_api.key")
 
         if os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy"):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -533,9 +533,13 @@ class TestSimbaSource:
 
 
 @pytest.mark.skipif(
-    not os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy")
+    not os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy"),
+    reason="sample data not locally available",
 )
-@pytest.mark.skipif(not os.path.isfile("examples/martini-cutout-TNG100-1-99-517.npy"))
+@pytest.mark.skipif(
+    not os.path.isfile("examples/martini-cutout-TNG100-1-99-517.hdf5"),
+    reason="sample data not locally available",
+)
 class TestTNGSource:
     def test_tng_notebook(self):
         pytest.importorskip(

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -603,11 +603,6 @@ class TestTNGSource:
             in nb_content
         )
 
-    @pytest.mark.skipif(
-        not os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy")
-        or not os.path.isfile("examples/martini-cutout-TNG100-1-99-517.hdf5"),
-        reason="sample data not locally available",
-    )
     def test_tng_notebook(self):
         """
         Check that the TNG example notebook runs.
@@ -619,6 +614,13 @@ class TestTNGSource:
         from nbmake.pytest_items import NotebookFailedException
         import pathlib
 
+        assert "TNG_API_KEY" in os.environ or os.path.isfile("examples/tng_api.key")
+
+        if os.path.isfile("examples/martini-cutout-grnr-TNG100-1-99-400547.npy"):
+            os.remove("examples/martini-cutout-grnr-TNG100-1-99-400547.npy")
+        if os.path.isfile("examples/martini-cutout-TNG100-1-99-517.hdf5"):
+            os.remove("examples/martini-cutout-TNG100-1-99-517.hdf5")
+
         nbr = NotebookRun(pathlib.Path("examples/martini_TNG.ipynb"), 3600)
         try:
             result = nbr.execute()
@@ -629,6 +631,8 @@ class TestTNGSource:
                 "examples/tng_martini_demo_beam.fits",
                 "examples/tng_martini_demo.fits",
                 "examples/tng_martini_demo.hdf5",
+                "examples/martini-cutout-TNG100-1-99-517.hdf5",
+                "examples/martini-cutout-grnr-TNG100-1-99-400547.npy",
             )
             for file_to_cleanup in files_to_cleanup:
                 if os.path.isfile(file_to_cleanup):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,19 @@
+from martini.__version__ import __version__
+
+
+class TestVersion:
+    def test_pyproject_version(self):
+        """
+        Check that pyproject version matches version file.
+        """
+        with open("pyproject.toml") as f:
+            pyproject_content = f.read()
+        assert 'version = "' + __version__ + '"' in pyproject_content
+
+    def test_codemeta_version(self):
+        """
+        Check that codemeta version matches version file.
+        """
+        with open("codemeta.json") as f:
+            codemeta_content = f.read()
+        assert '"version": "' + __version__ + '",' in codemeta_content


### PR DESCRIPTION
Add tests for jupyter notebooks that will run if simulation data is locally available. The TNG one could conceivable be set to run on github if the API key is passed in as a secret.

Todo:

- [x] Get TNG example running on github CI.
- [x] Make test for source injection example.

Closes #13 