### PR TITLE
Improved pruning

### DIFF
--- a/examples/martini_fire.ipynb
+++ b/examples/martini_fire.ipynb
@@ -512,9 +512,9 @@
     "            directory_download(url_base, urllib.parse.urljoin(directory, link[\"href\"]))\n",
     "\n",
     "\n",
-    "# if os.path.isdir(simulation_directory):\n",
-    "#     print(\"Found directory matching simulation_directory locally, skipping download.\")\n",
-    "# else:\n",
+    "if os.path.isdir(simulation_directory):\n",
+    "    print(\"Found directory matching simulation_directory locally, skipping download.\")\n",
+    "else:\n",
     "directory_download(data_url, simulation_directory)"
    ]
   },

--- a/martini/martini.py
+++ b/martini/martini.py
@@ -206,8 +206,8 @@ class _BaseMartini:
                 + mass_reject_conditions
             )
         )
-        self.source.apply_mask(np.logical_not(accept_mask))
-        self.sph_kernel._apply_mask(np.logical_not(accept_mask))
+        self.source.apply_mask(accept_mask)
+        self.sph_kernel._apply_mask(accept_mask)
         if not self.quiet:
             print(
                 f"Pruned particles that will not contribute to {obj_type_str}, "

--- a/martini/martini.py
+++ b/martini/martini.py
@@ -1559,6 +1559,7 @@ class GlobalProfile(_BaseMartini):
             _prune_kwargs=dict(
                 spatial=False,
                 spectral=True,
+                mass=True,
                 obj_type_str="spectrum",
             ),
             quiet=quiet,

--- a/martini/martini.pyi
+++ b/martini/martini.pyi
@@ -33,7 +33,11 @@ class _BaseMartini:
         _prune_kwargs: T.Dict[str, T.Union[bool, str]] = ...,
     ) -> None: ...
     def _prune_particles(
-        self, spatial: bool = ..., spectral: bool = ..., obj_type_str: str = ...
+        self,
+        spatial: bool = ...,
+        spectral: bool = ...,
+        mass: bool = ...,
+        obj_type_str: str = ...,
     ) -> None: ...
     def _evaluate_pixel_spectrum(
         self,

--- a/martini/sources/sph_source.py
+++ b/martini/sources/sph_source.py
@@ -312,7 +312,9 @@ class SPHSource(object):
             raise ValueError("Mask must have same length as particle arrays.")
         mask_sum = np.sum(mask)
         if mask_sum == 0:
-            raise RuntimeError("No source particles in target region.")
+            raise RuntimeError(
+                "No source particles in target region. (Or they all have zero HI mass.)"
+            )
         self.npart = mask_sum
         if not self.T_g.isscalar:
             self.T_g = self.T_g[mask]

--- a/martini/sources/sph_source.py
+++ b/martini/sources/sph_source.py
@@ -312,9 +312,7 @@ class SPHSource(object):
             raise ValueError("Mask must have same length as particle arrays.")
         mask_sum = np.sum(mask)
         if mask_sum == 0:
-            raise RuntimeError(
-                "No source particles in target region. (Or they all have zero HI mass.)"
-            )
+            raise RuntimeError("No non-zero mHI source particles in target region.")
         self.npart = mask_sum
         if not self.T_g.isscalar:
             self.T_g = self.T_g[mask]

--- a/tests/test_martini.py
+++ b/tests/test_martini.py
@@ -348,9 +348,12 @@ class TestMartini:
         # set distance so that 1kpc = 1arcsec
         distance = (1 * U.kpc / 1 / U.arcsec).to(U.Mpc, U.dimensionless_angles())
         source = single_particle_source(
-            distance=distance, ra=ra_off, dec=dec_off, vpeculiar=v_off
+            distance=distance,
+            ra=ra_off,
+            dec=dec_off,
+            vpeculiar=v_off,
+            mHI_g=mass_off * np.ones(1) * 1.0e4 * U.Msun,
         )
-        source.mHI_g *= mass_off
         datacube = DataCube(
             n_px_x=2,
             n_px_y=2,
@@ -380,8 +383,7 @@ class TestMartini:
         if not expect_particle:
             with pytest.raises(
                 RuntimeError,
-                match="No source particles in target region. "
-                "(Or they all have zero HI mass.)",
+                match="No non-zero mHI source particles in target region.",
             ):
                 _BaseMartini(**kwargs)
         else:
@@ -498,8 +500,7 @@ class TestMartini:
         )
         with pytest.raises(
             RuntimeError,
-            match="No source particles in target region. "
-            "(Or they all have zero HI mass.)",
+            match="No non-zero mHI source particles in target region.",
         ):
             Martini(
                 source=source,
@@ -564,8 +565,7 @@ class TestMartini:
         assert datacube_galactocentric.wcs.wcs.specsys == "galactocentric"
         with pytest.raises(
             RuntimeError,
-            match="No source particles in target region. "
-            "(Or they all have zero HI mass.)",
+            match="No non-zero mHI source particles in target region.",
         ):
             Martini(
                 source=source,
@@ -792,8 +792,7 @@ class TestGlobalProfile:
         if not expect_particle:
             with pytest.raises(
                 RuntimeError,
-                match="No source particles in target region. "
-                "(Or they all have zero HI mass.)",
+                match="No non-zero mHI source particles in target region.",
             ):
                 GlobalProfile(**kwargs)
         else:

--- a/tests/test_martini.py
+++ b/tests/test_martini.py
@@ -306,7 +306,7 @@ class TestMartini:
             (-7 * U.km / U.s, False),
         ),
     )
-    @pytest.mask.parametrize(("mass_off", "mass_in"), ((0, False), (1, True)))
+    @pytest.mark.parametrize(("mass_off", "mass_in"), ((0, False), (1, True)))
     @pytest.mark.parametrize("spatial", (True, False))
     @pytest.mark.parametrize("spectral", (True, False))
     @pytest.mark.parametrize("mass", (True, False))
@@ -379,7 +379,9 @@ class TestMartini:
         # if more than 1px (datacube) + 4px (4*spectrum_half_width) then expect to prune
         if not expect_particle:
             with pytest.raises(
-                RuntimeError, match="No source particles in target region."
+                RuntimeError,
+                match="No source particles in target region. "
+                "(Or they all have zero HI mass.)",
             ):
                 _BaseMartini(**kwargs)
         else:
@@ -494,7 +496,11 @@ class TestMartini:
             dec=source.dec,
             coordinate_frame=FK5(equinox="J1950"),
         )
-        with pytest.raises(RuntimeError, match="No source particles in target region."):
+        with pytest.raises(
+            RuntimeError,
+            match="No source particles in target region. "
+            "(Or they all have zero HI mass.)",
+        ):
             Martini(
                 source=source,
                 datacube=datacube_fk5_J1950,
@@ -556,7 +562,11 @@ class TestMartini:
             specsys="galactocentric",
         )
         assert datacube_galactocentric.wcs.wcs.specsys == "galactocentric"
-        with pytest.raises(RuntimeError, match="No source particles in target region."):
+        with pytest.raises(
+            RuntimeError,
+            match="No source particles in target region. "
+            "(Or they all have zero HI mass.)",
+        ):
             Martini(
                 source=source,
                 datacube=datacube_galactocentric,
@@ -781,7 +791,9 @@ class TestGlobalProfile:
         # if more than 1px (datacube) + 4px (4*spectrum_half_width) then expect to prune
         if not expect_particle:
             with pytest.raises(
-                RuntimeError, match="No source particles in target region."
+                RuntimeError,
+                match="No source particles in target region. "
+                "(Or they all have zero HI mass.)",
             ):
                 GlobalProfile(**kwargs)
         else:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -339,7 +339,9 @@ class TestSPHSource:
             ValueError, match="Mask must have same length as particle arrays."
         ):
             s.apply_mask(np.array([1, 2, 3]))
-        with pytest.raises(RuntimeError, match="No source particles in target region."):
+        with pytest.raises(
+            RuntimeError, match="No non-zero mHI source particles in target region."
+        ):
             s.apply_mask(np.zeros(s.npart, dtype=int))
 
     def test_rotate_axis_angle(self, s):


### PR DESCRIPTION
When pruning particles, we'd previously removed those outside of the spatial aperture and spectral bandwidth of the cube. Now we also remove those with mHI == 0, since they will never contribute to the output.