### PR TITLE
Don't write to attributes of `self` in threaded segment

### DIFF
--- a/martini/spectral_models.pyi
+++ b/martini/spectral_models.pyi
@@ -13,7 +13,6 @@ class _BaseSpectrum(metaclass=abc.ABCMeta):
     spectra: T.Optional[U.Quantity[U.Jy]]
     ncpu: int
     spec_dtype: type
-    spectral_function_extra_data: T.Optional[T.Dict[str, T.Any]]
 
     def __init__(self, ncpu: T.Optional[int] = ..., spec_dtype: type = ...) -> None: ...
     def init_spectra(self, source: SPHSource, datacube: DataCube) -> None: ...
@@ -31,13 +30,15 @@ class _BaseSpectrum(metaclass=abc.ABCMeta):
         a: U.Quantity[U.km / U.s],
         b: U.Quantity[U.km / U.s],
         vmids: U.Quantity[U.km / U.s],
+        extra_data: U.Optional[dict[str, U.Quantity]] = ...,
     ) -> U.Quantity[U.dimensionless_unscaled]: ...
-    def init_spectral_function_extra_data(
+    def get_spectral_function_extra_data(
         self,
         source: SPHSource,
         datacube: DataCube,
         mask: T.Union[slice, EllipsisType] = ...,
-    ) -> None: ...
+        extra_data: U.Optional[dict[str, U.Quantity]] = ...,
+    ) -> dict[str, U.Quantity]: ...
 
 class GaussianSpectrum(_BaseSpectrum):
     sigma_mode: T.Union[str, U.Quantity[U.km / U.s]]
@@ -53,13 +54,15 @@ class GaussianSpectrum(_BaseSpectrum):
         a: U.Quantity[U.km / U.s],
         b: U.Quantity[U.km / U.s],
         vmids: U.Quantity[U.km / U.s],
+        extra_data: U.Optional[dict[str, U.Quantity]] = ...,
     ) -> U.Quantity[U.dimensionless_unscaled]: ...
-    def init_spectral_function_extra_data(
+    def get_spectral_function_extra_data(
         self,
         source: SPHSource,
         datacube: DataCube,
         mask: T.Union[slice, EllipsisType] = ...,
-    ) -> None: ...
+        extra_data: U.Optional[dict[str, U.Quantity]] = ...,
+    ) -> dict[str, U.Quantity]: ...
     def half_width(self, source: SPHSource) -> U.Quantity[U.km / U.s]: ...
 
 class DiracDeltaSpectrum(_BaseSpectrum):
@@ -69,5 +72,6 @@ class DiracDeltaSpectrum(_BaseSpectrum):
         a: U.Quantity[U.km / U.s],
         b: U.Quantity[U.km / U.s],
         vmids: U.Quantity[U.km / U.s],
+        extra_data: U.Optional[dict[str, U.Quantity]] = ...,
     ) -> U.Quantity[U.dimensionless_unscaled]: ...
     def half_width(self, source: SPHSource) -> U.Quantity[U.km / U.s]: ...

--- a/tests/test_spectral_models.py
+++ b/tests/test_spectral_models.py
@@ -55,12 +55,13 @@ class TestGaussianSpectrum:
         datacube = DataCube(
             n_channels=64, channel_width=4 * U.km / U.s, spectral_centre=source.vsys
         )
-        spectral_model.init_spectral_function_extra_data(source, datacube)
+        extra_data = spectral_model.get_spectral_function_extra_data(source, datacube)
         spectrum = spectral_model.spectral_function(
             datacube.channel_edges[np.newaxis, 1:],
             datacube.channel_edges[np.newaxis, :-1],
             # expected from single_particle_source:
             U.Quantity([source.vsys])[:, np.newaxis],
+            extra_data=extra_data,
         )
         assert U.isclose(spectrum.sum(), 1.0 * U.dimensionless_unscaled, rtol=1.0e-4)
 
@@ -76,8 +77,7 @@ class TestGaussianSpectrum:
         datacube = DataCube(
             n_channels=64, channel_width=4 * U.km / U.s, spectral_centre=source.vsys
         )
-        spectral_model.init_spectral_function_extra_data(source, datacube)
-        extra_data = spectral_model.spectral_function_extra_data
+        extra_data = spectral_model.get_spectral_function_extra_data(source, datacube)
         assert set(extra_data.keys()) == {"sigma"}
         assert U.allclose(
             extra_data["sigma"].squeeze(), spectral_model.half_width(source)
@@ -139,8 +139,7 @@ class TestDiracDeltaSpectrum:
             n_channels=64, channel_width=4 * U.km / U.s, spectral_centre=source.vsys
         )
         spectral_model = DiracDeltaSpectrum()
-        spectral_model.init_spectral_function_extra_data(source, datacube)
-        extra_data = spectral_model.spectral_function_extra_data
+        extra_data = spectral_model.get_spectral_function_extra_data(source, datacube)
         assert len(extra_data) == 0
 
 


### PR DESCRIPTION
Recent update to use threads in spectrum initialisation could lead to threads competing to write to the same attributes, leading to potentially incorrect results when subsequently using those attributes. This patch fixes this issue.